### PR TITLE
Add resilience to APIs requests

### DIFF
--- a/Cognitive.LUIS.Programmatic.Tests/BaseTest.cs
+++ b/Cognitive.LUIS.Programmatic.Tests/BaseTest.cs
@@ -4,7 +4,7 @@ namespace Cognitive.LUIS.Programmatic.Tests
 {
     public abstract class BaseTest : IDisposable
     {
-        protected const string SubscriptionKey = "{YourSubscriptionKey}";
+        protected const string SubscriptionKey = "a2b9d6bd1c31416ca3fd18e09238b545";
         protected const Regions Region = Regions.WestUS;
         protected const string InvalidId = "51593248-363e-4a08-b946-2061964dc690";
         protected const string appVersion = "1.0";

--- a/Cognitive.LUIS.Programmatic.sln
+++ b/Cognitive.LUIS.Programmatic.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2010
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29020.237
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cognitive.LUIS.Programmatic", "Cognitive.LUIS.Programmatic\Cognitive.LUIS.Programmatic.csproj", "{4420B09A-7F25-4E57-8088-A3B75FBD4F4C}"
 EndProject

--- a/Cognitive.LUIS.Programmatic/AppService.cs
+++ b/Cognitive.LUIS.Programmatic/AppService.cs
@@ -9,8 +9,10 @@ namespace Cognitive.LUIS.Programmatic.Apps
 {
     public class AppService : ServiceClient, IAppService
     {
-        public AppService(string subscriptionKey, Regions region)
-            : base(subscriptionKey, region) { }
+        public AppService(string subscriptionKey, 
+                          Regions region, 
+                          RetryPolicyConfiguration retryPolicyConfiguration = null)
+            : base(subscriptionKey, region, retryPolicyConfiguration) { }
 
         /// <summary>
         /// Lists all of the user applications
@@ -65,12 +67,12 @@ namespace Cognitive.LUIS.Programmatic.Apps
         {
             var app = new
             {
-                name = name,
-                description = description,
-                culture = culture,
-                usageScenario = usageScenario,
-                domain = domain,
-                initialVersionId = initialVersionId
+                name,
+                description,
+                culture,
+                usageScenario,
+                domain,
+                initialVersionId
             };
             var response = await Post($"apps", app);
             return JsonConvert.DeserializeObject<string>(response);
@@ -87,8 +89,8 @@ namespace Cognitive.LUIS.Programmatic.Apps
         {
             var app = new
             {
-                name = name,
-                description = description
+                name,
+                description
             };
             await Put($"apps/{id}", app);
         }

--- a/Cognitive.LUIS.Programmatic/Cognitive.LUIS.Programmatic.csproj
+++ b/Cognitive.LUIS.Programmatic/Cognitive.LUIS.Programmatic.csproj
@@ -26,6 +26,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Polly" Version="7.1.0" />
   </ItemGroup>
 
 </Project>

--- a/Cognitive.LUIS.Programmatic/EntityService.cs
+++ b/Cognitive.LUIS.Programmatic/EntityService.cs
@@ -9,8 +9,8 @@ namespace Cognitive.LUIS.Programmatic.Entities
 {
     public class EntityService : ServiceClient, IEntityService
     {
-        public EntityService(string subscriptionKey, Regions region)
-            : base(subscriptionKey, region) { }
+        public EntityService(string subscriptionKey, Regions region, RetryPolicyConfiguration retryPolicyConfiguration = null)
+            : base(subscriptionKey, region, retryPolicyConfiguration) { }
 
         /// <summary>
         /// Gets information about the simple entity models
@@ -248,7 +248,7 @@ namespace Cognitive.LUIS.Programmatic.Entities
         {
             var entity = new
             {
-                name = name
+                name
             };
             var response = await Post($"apps/{appId}/versions/{appVersionId}/entities", entity);
             return JsonConvert.DeserializeObject<string>(response);
@@ -266,8 +266,8 @@ namespace Cognitive.LUIS.Programmatic.Entities
         {
             var entity = new
             {
-                name = name,
-                children = children
+                name,
+                children
             };
             var response = await Post($"apps/{appId}/versions/{appVersionId}/compositeentities", entity);
             return JsonConvert.DeserializeObject<string>(response);
@@ -285,7 +285,7 @@ namespace Cognitive.LUIS.Programmatic.Entities
         {
             var entity = new
             {
-                name = name,
+                name,
                 sublists = subLists
             };
             var response = await Post($"apps/{appId}/versions/{appVersionId}/closedlists", entity);
@@ -304,8 +304,8 @@ namespace Cognitive.LUIS.Programmatic.Entities
         {
             var entity = new
             {
-                name = name,
-                regexPattern = regexPattern
+                name,
+                regexPattern
             };
             var response = await Post($"apps/{appId}/versions/{appVersionId}/regexentities", entity);
             return JsonConvert.DeserializeObject<string>(response);
@@ -323,8 +323,8 @@ namespace Cognitive.LUIS.Programmatic.Entities
         {
             var entity = new
             {
-                name = name,
-                explicitList = explicitList
+                name,
+                explicitList
             };
             var response = await Post($"apps/{appId}/versions/{appVersionId}/patternanyentities", entity);
             return JsonConvert.DeserializeObject<string>(response);
@@ -342,7 +342,7 @@ namespace Cognitive.LUIS.Programmatic.Entities
         {
             var entity = new
             {
-                name = name
+                name
             };
             await Put($"apps/{appId}/versions/{appVersionId}/entities/{id}", entity);
         }

--- a/Cognitive.LUIS.Programmatic/ExampleService.cs
+++ b/Cognitive.LUIS.Programmatic/ExampleService.cs
@@ -8,8 +8,8 @@ namespace Cognitive.LUIS.Programmatic.Examples
 {
     public class ExampleService : ServiceClient, IExampleService
     {
-        public ExampleService(string subscriptionKey, Regions region)
-            : base(subscriptionKey, region) { }
+        public ExampleService(string subscriptionKey, Regions region, RetryPolicyConfiguration retryPolicyConfiguration = null)
+            : base(subscriptionKey, region, retryPolicyConfiguration) { }
 
         /// <summary>
         /// Gets examples to be reviewed.

--- a/Cognitive.LUIS.Programmatic/IntentService.cs
+++ b/Cognitive.LUIS.Programmatic/IntentService.cs
@@ -9,8 +9,8 @@ namespace Cognitive.LUIS.Programmatic.Intents
 {
     public class IntentService : ServiceClient, IIntentService
     {
-        public IntentService(string subscriptionKey, Regions region)
-            : base(subscriptionKey, region) { }
+        public IntentService(string subscriptionKey, Regions region, RetryPolicyConfiguration retryPolicyConfiguration = null)
+            : base(subscriptionKey, region, retryPolicyConfiguration) { }
 
         /// <summary>
         /// Gets information about the intent models
@@ -71,7 +71,7 @@ namespace Cognitive.LUIS.Programmatic.Intents
         {
             var intent = new
             {
-                name = name
+                name
             };
             var response = await Post($"apps/{appId}/versions/{appVersionId}/intents", intent);
             return JsonConvert.DeserializeObject<string>(response);
@@ -89,7 +89,7 @@ namespace Cognitive.LUIS.Programmatic.Intents
         {
             var intent = new
             {
-                name = name
+                name
             };
             await Put($"apps/{appId}/versions/{appVersionId}/intents/{id}", intent);
         }

--- a/Cognitive.LUIS.Programmatic/LuisProgClient.cs
+++ b/Cognitive.LUIS.Programmatic/LuisProgClient.cs
@@ -33,13 +33,13 @@ namespace Cognitive.LUIS.Programmatic
 
         public void Dispose()
         {
-            Apps.Dispose();
-            Entities.Dispose();
-            Examples.Dispose();
-            Intents.Dispose();
-            Publishing.Dispose();
-            Versions.Dispose();
-            Training.Dispose();
+            Apps?.Dispose();
+            Entities?.Dispose();
+            Examples?.Dispose();
+            Intents?.Dispose();
+            Publishing?.Dispose();
+            Versions?.Dispose();
+            Training?.Dispose();
         }
     }
 }

--- a/Cognitive.LUIS.Programmatic/Models/Common/Error.cs
+++ b/Cognitive.LUIS.Programmatic/Models/Common/Error.cs
@@ -2,6 +2,12 @@ namespace Cognitive.LUIS.Programmatic.Models
 {
     public class Error
     {
+        public static string[] ERROR_LIST = new string[] {
+            "Unspecified", "Unauthorized", "BadRequest", "TooManyRequests", "Forbidden"
+        };
+
+        public const string UNEXPECTED_ERROR_CODE = "Unexpected";
+
         public string Code { get; set; }
         public string Message { get; set; }
     }

--- a/Cognitive.LUIS.Programmatic/Models/Common/ServiceException.cs
+++ b/Cognitive.LUIS.Programmatic/Models/Common/ServiceException.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Cognitive.LUIS.Programmatic.Models
 {
     public class ServiceException
@@ -5,7 +7,13 @@ namespace Cognitive.LUIS.Programmatic.Models
         public Error Error { get; set; }
         public string Message { get; set; }
 
+        public Exception ToException()
+        {
+            var errorMessage = ToString();
+            return new Exception(errorMessage);
+        }
+
         public override string ToString() =>
-            $"{Error?.Code ?? "Unexpected"} - {Error?.Message ?? Message}";
+            $"{Error?.Code ?? Error.UNEXPECTED_ERROR_CODE} - {Error?.Message ?? Message}";
     }
 }

--- a/Cognitive.LUIS.Programmatic/PublishService.cs
+++ b/Cognitive.LUIS.Programmatic/PublishService.cs
@@ -6,8 +6,8 @@ namespace Cognitive.LUIS.Programmatic
 {
     public class PublishService : ServiceClient, IPublishService
     {
-        public PublishService(string subscriptionKey, Regions region)
-            : base(subscriptionKey, region) { }
+        public PublishService(string subscriptionKey, Regions region, RetryPolicyConfiguration retryPolicyConfiguration = null)
+            : base(subscriptionKey, region, retryPolicyConfiguration) { }
 
         /// <summary>
         /// Publishes a specific version of the application
@@ -23,7 +23,7 @@ namespace Cognitive.LUIS.Programmatic
             {
                 versionId = appVersionId,
                 isStaging = isStaging.ToString(),
-                directVersionPublish = directVersionPublish
+                directVersionPublish
             };
             var response = await Post($"apps/{appId}/publish", model);
             return JsonConvert.DeserializeObject<Publish>(response);

--- a/Cognitive.LUIS.Programmatic/RetryPolicyConfiguration.cs
+++ b/Cognitive.LUIS.Programmatic/RetryPolicyConfiguration.cs
@@ -1,0 +1,16 @@
+﻿namespace Cognitive.LUIS.Programmatic
+{
+    public class RetryPolicyConfiguration
+    {
+        public static RetryPolicyConfiguration Default = new RetryPolicyConfiguration(3, 1);
+
+        public int RetryCount { get; private set; }
+        public int RetryAttemptFactor { get; private set; }
+
+        public RetryPolicyConfiguration(int retryCount, int retryAttemptFactor)
+        {
+            this.RetryCount = retryCount;
+            this.RetryAttemptFactor = retryAttemptFactor;
+        }
+    }
+}

--- a/Cognitive.LUIS.Programmatic/ServiceClient.cs
+++ b/Cognitive.LUIS.Programmatic/ServiceClient.cs
@@ -1,7 +1,10 @@
 ﻿using Cognitive.LUIS.Programmatic.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Polly;
+using Polly.Retry;
 using System;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -11,63 +14,77 @@ namespace Cognitive.LUIS.Programmatic
 {
     public class ServiceClient : IDisposable
     {
-        private readonly HttpClient _client;
+        private static readonly MediaTypeHeaderValue CONTENT_TYPE = new MediaTypeHeaderValue("application/json");
 
-        public ServiceClient(string subscriptionKey, Regions region)
+        private readonly HttpClient _client;
+        private readonly AsyncRetryPolicy _policy;
+
+        public ServiceClient(string subscriptionKey, Regions region, RetryPolicyConfiguration retryPolicyConfiguration)
         {
             var baseUrl = $"https://{region.ToString().ToLower()}.api.cognitive.microsoft.com/luis/api/v2.0/";
             _client = HttpClientFactory.Create(baseUrl, subscriptionKey);
+            _policy = GetPolicy(retryPolicyConfiguration ?? RetryPolicyConfiguration.Default);
         }
 
         protected async Task<string> Get(string path)
         {
-            var response = await _client.GetAsync(path);
-            var responseContent = await response.Content.ReadAsStringAsync();
-            if (response.IsSuccessStatusCode)
-                return responseContent;
-            else if (response.StatusCode != System.Net.HttpStatusCode.BadRequest)
+            return await _policy.ExecuteAsync(async () =>
             {
-                var exception = JsonConvert.DeserializeObject<ServiceException>(responseContent);
-                var errorMessage = exception.Message;
-                
-                if (exception.Error != null)
-                    errorMessage = $"{exception.Error.Code} - {exception.Error.Message}";
-                
-                throw new Exception(errorMessage);
-            }
-            return null;
+                var response = await _client.GetAsync(path);
+                var responseContent = await response.Content.ReadAsStringAsync();
+                if (response.IsSuccessStatusCode)
+                    return responseContent;
+                else if (response.StatusCode != System.Net.HttpStatusCode.BadRequest)
+                {
+                    var serviceException = JsonConvert.DeserializeObject<ServiceException>(responseContent);
+                    throw serviceException.ToException();
+                }
+                return null;
+            });
         }
 
         protected async Task<string> Post(string path)
         {
-            var response = await _client.PostAsync(path, null);
-            return await GetResponseContent(response);
+            return await _policy.ExecuteAsync(async () =>
+            {
+                var response = await _client.PostAsync(path, null);
+                return await GetResponseContent(response);
+            });
         }
 
         protected async Task<string> Post<TRequest>(string path, TRequest requestBody)
         {
-            using (var content = new ByteArrayContent(GetByteData(requestBody)))
+            return await _policy.ExecuteAsync(async () =>
             {
-                content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-                var response = await _client.PostAsync(path, content);
-                return await GetResponseContent(response);
-            }
+                using (var content = new ByteArrayContent(GetByteData(requestBody)))
+                {
+                    content.Headers.ContentType = CONTENT_TYPE;
+                    var response = await _client.PostAsync(path, content);
+                    return await GetResponseContent(response);
+                }
+            });
         }
 
         protected async Task Put<TRequest>(string path, TRequest requestBody)
         {
-            using (var content = new ByteArrayContent(GetByteData(requestBody)))
+            await _policy.ExecuteAsync(async () =>
             {
-                content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-                var response = await _client.PutAsync(path, content);
-                await GetResponseContent(response);
-            }
+                using (var content = new ByteArrayContent(GetByteData(requestBody)))
+                {
+                    content.Headers.ContentType = CONTENT_TYPE;
+                    var response = await _client.PutAsync(path, content);
+                    await GetResponseContent(response);
+                }
+            });
         }
 
         protected async Task Delete(string path)
         {
-            var response = await _client.DeleteAsync(path);
-            await GetResponseContent(response);
+            await _policy.ExecuteAsync(async () =>
+            {
+                var response = await _client.DeleteAsync(path);
+                await GetResponseContent(response);
+            });
         }
 
         private async Task<string> GetResponseContent(HttpResponseMessage response)
@@ -75,8 +92,8 @@ namespace Cognitive.LUIS.Programmatic
             var responseContent = await response.Content.ReadAsStringAsync();
             if (!response.IsSuccessStatusCode)
             {
-                var exception = JsonConvert.DeserializeObject<ServiceException>(responseContent);
-                throw new Exception(exception.ToString());
+                var serviceException = JsonConvert.DeserializeObject<ServiceException>(responseContent);
+                throw serviceException.ToException();
             }
             return responseContent;
         }
@@ -86,6 +103,28 @@ namespace Cognitive.LUIS.Programmatic
             var settings = new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() };
             var body = JsonConvert.SerializeObject(requestBody, settings);
             return Encoding.UTF8.GetBytes(body);
+        }
+
+        private AsyncRetryPolicy GetPolicy(RetryPolicyConfiguration retryPolicyConfiguration)
+        {
+            return Policy
+            .Handle<Exception>(e =>
+            {
+                var errorCode = e.Message.Split('-')
+                                         .Select(p => p.Trim())
+                                         .FirstOrDefault();
+
+                if (string.IsNullOrEmpty(errorCode))
+                    return false;
+
+                if (errorCode == Error.UNEXPECTED_ERROR_CODE)
+                    return false;
+
+                return Error.ERROR_LIST.Contains(errorCode);
+            })
+            .WaitAndRetryAsync(retryPolicyConfiguration.RetryCount, retryAttempt =>
+                TimeSpan.FromSeconds(Math.Pow(2, retryPolicyConfiguration.RetryAttemptFactor))
+            );
         }
 
         public void Dispose() =>

--- a/Cognitive.LUIS.Programmatic/TrainingService.cs
+++ b/Cognitive.LUIS.Programmatic/TrainingService.cs
@@ -10,8 +10,8 @@ namespace Cognitive.LUIS.Programmatic.Training
 {
     public class TrainingService : ServiceClient, ITrainingService
     {
-        public TrainingService(string subscriptionKey, Regions region)
-            : base(subscriptionKey, region) { }
+        public TrainingService(string subscriptionKey, Regions region, RetryPolicyConfiguration retryPolicyConfiguration = null)
+            : base(subscriptionKey, region, retryPolicyConfiguration) { }
 
         /// <summary>
         /// Sends a training request for a version of a specified LUIS app

--- a/Cognitive.LUIS.Programmatic/VersionService.cs
+++ b/Cognitive.LUIS.Programmatic/VersionService.cs
@@ -7,8 +7,8 @@ namespace Cognitive.LUIS.Programmatic.Versions
 {
     public class VersionService : ServiceClient, IVersionService
     {
-        public VersionService(string subscriptionKey, Regions region)
-            : base(subscriptionKey, region) { }
+        public VersionService(string subscriptionKey, Regions region, RetryPolicyConfiguration retryPolicyConfiguration = null)
+            : base(subscriptionKey, region, retryPolicyConfiguration) { }
 
         /// <summary>
         /// Gets the application versions info


### PR DESCRIPTION
LUIS APIs there is a request limit. (https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-boundaries#key-limits)
When the rate limit was reached, the API send a 429 HTTP Status.
And we know that LUIS APIs, somethimes, gets instability.
The main pourpose is adding Polly to create a resilients requests. (https://github.com/App-vNext/Polly)